### PR TITLE
Typo in formamide docs

### DIFF
--- a/manual.html
+++ b/manual.html
@@ -2232,7 +2232,7 @@ and J Hutton. Biopolymers, 19:1315–1327, 1980).</p>
 <h3><a id="PRIMER_INTERNAL_DMSO_FACTOR">PRIMER_INTERNAL_DMSO_FACTOR (float; default 0.6)</a></h3>
 <p>Equivalent parameter of <a href="#PRIMER_DMSO_FACTOR">PRIMER_DMSO_FACTOR</a> for the internal oligo.</p>
 <h3><a id="PRIMER_FORMAMIDE_CONC">PRIMER_FORMAMIDE_CONC (float; default 0.0)</a></h3>
-<p>The concentration od DMSO in mol/l. The melting temperature
+<p>The concentration of formamide in mol/l. The melting temperature
 of primers can be approximately corrected for formamide:<br>
 <br>
 Tm = Tm (without formamide) +(0.453 * PRIMER_[LEFT/INTERNAL/RIGHT]_4_GC_PERCENT / 100 - 2.88) * PRIMER_FORMAMIDE_CONC<br>


### PR DESCRIPTION
1. `od` -> `of`
2. I think we mean _formamid_ and not _DMSO_ here